### PR TITLE
Update vmwarerepair.sh to work with warning output and older versions

### DIFF
--- a/vmwarerepair.sh
+++ b/vmwarerepair.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Get the VMware Player version
-vmware_version=$(vmplayer -v | grep -oE 'Player 17\.[0-9]+\.[0-9]+' | awk '{print $2}')
+# Get the VMware Player version and redirect stderr to /dev/null to ignore warnings
+vmware_version=$(vmplayer -v 2>/dev/null | grep -oE 'VMware Player [0-9]+\.[0-9]+\.[0-9]+' | awk '{print $3}')
 
 # Check if the version is found
 if [ -z "$vmware_version" ]; then


### PR DESCRIPTION
Fixes repairing in case the output from vmplayer -v is as follows:
```
➜  vmwarerepair git:(main) vmplayer -v        
I/O warning : failed to load external entity "/etc/vmware/hostd/proxy.xml"
VMware Player 16.2.5 build-20904516
```